### PR TITLE
fix ngOnDestroy undefined calendar

### DIFF
--- a/projects/fullcalendar/src/lib/fullcalendar.component.ts
+++ b/projects/fullcalendar/src/lib/fullcalendar.component.ts
@@ -132,7 +132,9 @@ export class FullCalendarComponent implements AfterViewInit, DoCheck, OnChanges,
   }
 
   ngOnDestroy() {
-    this.calendar.destroy();
+    if (this.calendar) {
+      this.calendar.destroy();
+    }
     this.calendar = null;
   }
 


### PR DESCRIPTION
Added a simple check in the ngOnDestroy method because if it got called before the ngAfterViewInit, this.calendar would be undefined and so would cause an error. This happenend to me while doing unit test on my project, because the component never reached ngAfterViewInit before being destroyed.