### PR TITLE
docs: include Angular v21 in `README.md` support range

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can even supply nested templates:
 
 ## Supported Angular Versions
 
-`@fullcalendar/angular` version 6 supports Angular 12 - 20
+`@fullcalendar/angular` version 6 supports Angular 12 - 21
 
 ## Links
 


### PR DESCRIPTION
I see from the main repo that v21 is supported in FullCalendar 6.1.20 https://github.com/fullcalendar/fullcalendar/releases/tag/v6.1.20. 

Thank you for this package, cheers.